### PR TITLE
fix and update flake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,12 @@
+name: build
+on: [pull_request, push]
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v19
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+    - run: nix build
+    - run: nix flake check

--- a/flake.lock
+++ b/flake.lock
@@ -8,40 +8,26 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1678775037,
-        "narHash": "sha256-chx0tWnXKpcayPkPY3Qh+2hNwptvX8XE3o+fYZ+GNzg=",
+        "lastModified": 1681971746,
+        "narHash": "sha256-RAFvwcAds5WeCSUYONE+YzR0uKVuLc6BIeN4WFix4f0=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "ee59e1c769657b1e27e608f8b981fa8f6b715583",
+        "rev": "3a0b59a2ea946a533c62ac417596835779087f0e",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "fenix",
         "type": "github"
-      }
-    },
-    "flake-utils": {
-      "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
-        "type": "github"
-      },
-      "original": {
-        "id": "flake-utils",
-        "type": "indirect"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678703398,
-        "narHash": "sha256-Y1mW3dBsoWLHpYm+UIHb5VZ7rx024NNHaF16oZBx++o=",
+        "lastModified": 1681759395,
+        "narHash": "sha256-7aaRtLxLAy8qFVIA26ulB+Q5nDVzuQ71qi0s0wMjAws=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "67f26c1cfc5d5783628231e776a81c1ade623e0b",
+        "rev": "cd749f58ba83f7155b7062dd49d08e5e47e44d50",
         "type": "github"
       },
       "original": {
@@ -54,18 +40,17 @@
     "root": {
       "inputs": {
         "fenix": "fenix",
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }
     },
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1678695923,
-        "narHash": "sha256-rDhiiU8P6sf6mgj5IKgCuTRN9uYeqWr6xl4XLkKnMWg=",
+        "lastModified": 1681913140,
+        "narHash": "sha256-+m+eXpFa5c8nQ4hAZyshIjovKzhMfd5Eo6jQDk6eeig=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "95497533524537b1cc7a2870ce94b0b14503be8b",
+        "rev": "2400b36a2ed40f68a26473f69ac208ba10d98af9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1678775037,
+        "narHash": "sha256-chx0tWnXKpcayPkPY3Qh+2hNwptvX8XE3o+fYZ+GNzg=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "ee59e1c769657b1e27e608f8b981fa8f6b715583",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1678703398,
+        "narHash": "sha256-Y1mW3dBsoWLHpYm+UIHb5VZ7rx024NNHaF16oZBx++o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "67f26c1cfc5d5783628231e776a81c1ade623e0b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1678695923,
+        "narHash": "sha256-rDhiiU8P6sf6mgj5IKgCuTRN9uYeqWr6xl4XLkKnMWg=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "95497533524537b1cc7a2870ce94b0b14503be8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -31,9 +31,8 @@
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
+        "id": "flake-utils",
+        "type": "indirect"
       }
     },
     "nixpkgs": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,8 @@
     flake-utils.lib.simpleFlake {
       inherit self nixpkgs;
       name = "stardust-xr";
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+
       overlay = pkgs: prev:
         let
           toolchain = fenix.packages.${pkgs.system}.minimal.toolchain;

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs.fenix.url = github:nix-community/fenix;
   inputs.fenix.inputs.nixpkgs.follows = "nixpkgs";
 
-  outputs = { self, nixpkgs, fenix, flake-utils }:
+  outputs = { self, nixpkgs, fenix }:
     let
       name = "server";
       pkgs = system: import nixpkgs {
@@ -27,13 +27,14 @@
           }).buildRustPackage rec {
             pname = "stardust-xr-${name}";
             src = ./.;
+            cargoDepsName = pname;
 
             # ---- START package specific settings ----
-            version = "20230314";
-            cargoSha256 = "sha256-H6qhpvm6Dqn6EETCtgAcT/iof9ZZHm0ahTkX9cChows=";
+            version = "20230420";
+            cargoSha256 = "sha256-sIs8EKGPTCs+1aOACNB0oHoX/jomjIUBlMeBD0dTJdM=";
 
             postPatch = ''
-              sk=/build/${pname}-${version}-vendor.tar.gz/stereokit-sys/StereoKit
+              sk=/build/${pname}-vendor.tar.gz/stereokit-sys/StereoKit
               mkdir -p $sk/build/cpm
               cp ${pkgs.fetchurl {
                 url = "https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.32.2/CPM.cmake";

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,64 @@
+{
+  inputs.nixpkgs.url = github:NixOS/nixpkgs/nixos-22.11;
+
+  inputs.fenix.url = github:nix-community/fenix;
+  inputs.fenix.inputs.nixpkgs.follows = "nixpkgs";
+
+  inputs.flake-utils.url = github:numtide/flake-utils;
+
+  outputs = { self, nixpkgs, fenix, flake-utils }:
+    flake-utils.lib.simpleFlake {
+      inherit self nixpkgs;
+      name = "stardust-xr";
+      overlay = pkgs: prev:
+        let
+          toolchain = fenix.packages.${pkgs.system}.minimal.toolchain;
+
+          name = "server";
+          pkg = (pkgs.makeRustPlatform {
+            cargo = toolchain;
+            rustc = toolchain;
+          }).buildRustPackage rec {
+            pname = "stardust-xr-${name}";
+            src = ./.;
+
+            # ---- START package specific settings ----
+            version = "20230314";
+            cargoSha256 = "sha256-H6qhpvm6Dqn6EETCtgAcT/iof9ZZHm0ahTkX9cChows=";
+
+            postPatch = ''
+              sk=/build/${pname}-${version}-vendor.tar.gz/stereokit-sys/StereoKit
+              mkdir -p $sk/build/cpm
+              cp ${pkgs.fetchurl {
+                url = "https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.32.2/CPM.cmake";
+                hash = "sha256-yDHlpqmpAE8CWiwJRoWyaqbuBAg0090G8WJIC2KLHp8=";
+              }} $sk/build/cpm/CPM_0.32.2.cmake
+            '';
+
+            CPM_SOURCE_CACHE = "./build";
+
+            nativeBuildInputs = with pkgs; [
+              cmake pkg-config llvmPackages.libcxxClang
+            ];
+
+            buildInputs = with pkgs; [
+              openxr-loader libGL mesa xorg.libX11 fontconfig libxkbcommon
+            ];
+
+            LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+            # ---- END package specific settings ----
+          };
+        in
+        {
+          stardust-xr.${name} = pkg;
+          stardust-xr.defaultPackage = pkg;
+        };
+      shell = { pkgs }: pkgs.mkShell {
+        inputsFrom = [ pkgs.stardust-xr.defaultPackage ];
+
+        # ---- START package specific dev settings ----
+        LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+        # ---- END package specific dev settings ----
+      };
+    };
+}


### PR DESCRIPTION
basically, everytime the dependencies are updated the sha-256 needs to be updated as well. so far, I have not found a reliable way to do this ahead of time, but just looking at the error logs of a failed build should give the new sha-256