### PR TITLE
flake: fix smithay lock issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 **/*.rs.bk
 
 .vscode/
+
+# Ignore build results from Nix
+*result*

--- a/flake.nix
+++ b/flake.nix
@@ -34,9 +34,7 @@
 
             cargoLock = {
               lockFile = ./Cargo.lock;
-              outputHashes = {
-                "smithay-0.3.0" = "sha256-meEbYmSGQbaSbP5t55R1C/c9KNKvk20wDhPBCsT7kOY=";
-              };
+              allowBuiltinFetchGit = true;
             };
 
             postPatch = ''


### PR DESCRIPTION
using the builtin fetcher allows fetching git dependencies with only the ref and without storing the narHash for the fixed-output-derivation

I also added a `.gitignore` for Nix results 