### PR TITLE
Tracking Dbus interface

### DIFF
--- a/src/objects/input/sk_controller.rs
+++ b/src/objects/input/sk_controller.rs
@@ -7,7 +7,7 @@ use crate::{
 		input::{INPUT_HANDLER_REGISTRY, InputDataType, InputHandler, InputMethod, Tip},
 		spatial::Spatial,
 	},
-	objects::{ObjectHandle, SpatialRef},
+	objects::{ObjectHandle, SpatialRef, Tracked},
 };
 use color_eyre::eyre::Result;
 use glam::{Mat4, Vec2, Vec3};
@@ -40,18 +40,18 @@ pub struct SkController {
 	material: Material,
 	capture_manager: CaptureManager,
 	datamap: ControllerDatamap,
+	tracked: ObjectHandle<Tracked>,
 }
 impl SkController {
 	pub fn new(connection: &Connection, handed: Handed) -> Result<Self> {
 		Input::set_controller_model(handed, Some(Model::new()));
-		let (spatial, object_handle) = SpatialRef::create(
-			connection,
-			&("/org/stardustxr/Controller/".to_string()
-				+ match handed {
-					Handed::Left => "left",
-					_ => "right",
-				}),
-		);
+		let path = "/org/stardustxr/Controller/".to_string()
+			+ match handed {
+				Handed::Left => "left",
+				_ => "right",
+			};
+		let (spatial, object_handle) = SpatialRef::create(connection, &path);
+		let tracked = Tracked::new(connection, &path);
 		let model = Model::copy(&Model::from_memory(
 			"cursor.glb",
 			include_bytes!("cursor.glb"),
@@ -75,13 +75,22 @@ impl SkController {
 			material,
 			capture_manager: CaptureManager::default(),
 			datamap: Default::default(),
+			tracked,
 		})
 	}
 	pub fn update(&mut self, token: &MainThreadToken) {
 		let controller = Input::controller(self.handed);
 		let input_node = self.input.spatial.node().unwrap();
 		input_node.set_enabled(controller.tracked.is_active());
-		if input_node.enabled() {
+		let enabled = input_node.enabled();
+		tokio::spawn({
+			// this is suboptimal since it probably allocates a fresh string every frame
+			let handle = self.tracked.clone();
+			async move {
+				handle.set_tracked(enabled).await;
+			}
+		});
+		if enabled {
 			let world_transform = Mat4::from_rotation_translation(
 				controller.aim.orientation.into(),
 				controller.aim.position.into(),

--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -14,7 +14,6 @@ use input::{
 	sk_hand::SkHand,
 };
 use play_space::PlaySpaceBounds;
-use portable_atomic::AtomicBool;
 use stardust_xr::schemas::dbus::object_registry::ObjectRegistry;
 use std::{
 	marker::PhantomData,
@@ -207,7 +206,7 @@ pub struct ObjectHandle<I: Interface>(Connection, OwnedObjectPath, PhantomData<I
 
 impl<I: Interface> Clone for ObjectHandle<I> {
 	fn clone(&self) -> Self {
-		Self(self.0.clone(), self.1.clone(), PhantomData::default())
+		Self(self.0.clone(), self.1.clone(), PhantomData)
 	}
 }
 impl<I: Interface> Drop for ObjectHandle<I> {
@@ -260,11 +259,9 @@ impl SpatialRef {
 pub struct Tracked(bool);
 impl Tracked {
 	pub fn new(connection: &Connection, path: &str) -> ObjectHandle<Tracked> {
-		let bool = Arc::new(AtomicBool::new(false));
 		tokio::task::spawn({
 			let connection = connection.clone();
 			let path = path.to_string();
-			let bool = bool.clone();
 			async move {
 				connection
 					.object_server()


### PR DESCRIPTION
allows clients to query if a controller or hand is actively tracked, this can for example be used to hide ui anchored to a controller or hand so that it doesn't hang around *somewhere* when tracking is lost or the user switches between controllers and handtracking.

the client side will live in molecules